### PR TITLE
Specify minimum nodejs version (8.11 is current LTS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "webpack": "^4.10.2",
     "webpack-cli": "^2.1.4",
     "webpack-stream": "^3.2.0"
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": "~8.11"
   }
 }


### PR DESCRIPTION
@timwright12 does this node version work for you? 8.11.2 is the current LTS version.