### PR TITLE
Correct @package documentation for core.php file.

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -2,7 +2,7 @@
 /**
  * Core plugin functionality.
  *
- * @package ThemeScaffold
+ * @package PluginScaffold
  */
 
 namespace TenUpScaffold\Core;


### PR DESCRIPTION
This PR corrects the @ package documentation for the `core.php` file.

Found it because of working in conjunct with theme-scaffold and got a little confused. Probably a remanent of it.