### PR TITLE
Added autoprefixer property to cssOpts to work with CSS Grid

### DIFF
--- a/gulp-tasks/css.js
+++ b/gulp-tasks/css.js
@@ -13,7 +13,10 @@ gulp.task( 'css', ( cb ) => {
 	const fileDest = './dist';
 
 	const cssOpts = {
-		stage: 0
+		stage: 0,
+		autoprefixer: {
+			grid: true
+		}
 	};
 	const taskOpts = [
 		require( 'postcss-import' ),


### PR DESCRIPTION
Fixes an issue where `display:grid` is not autoprefixed in compiled files by `postcss-preset-env`.