### PR TITLE
Update css nano task options to be object instead of array.

### DIFF
--- a/gulp-tasks/cssnano.js
+++ b/gulp-tasks/cssnano.js
@@ -11,14 +11,14 @@ gulp.task( 'cssnano', ( cb ) => {
 		fileSrc = [
 			'./dist/*.css'
 		],
-		taskOpts = [cssnano( {
+		taskOpts = {
 			autoprefixer: false,
 			calc: {
 				precision: 8
 			},
 			zindex: false,
 			convertValues: true
-		} )];
+		};
 
 	pump( [
 		gulp.src( fileSrc ),


### PR DESCRIPTION
Fixes an issue described in the theme scaffold https://github.com/10up/theme-scaffold/issues/69

The same bug for CSS nano task options exists in the plugin scaffold.