### PR TITLE
use filter to allow hooking of defer/async on assets

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -27,6 +27,8 @@ function setup() {
 
 	// Editor styles. add_editor_style() doesn't work outside of a theme.
 	add_filter( 'mce_css', $n( 'mce_css' ) );
+	// Hook to allow async or defer on asset loading.
+	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
 
 	do_action( 'tenup_scaffold_loaded' );
 }
@@ -242,4 +244,38 @@ function mce_css( $stylesheets ) {
 	return $stylesheets . TENUP_SCAFFOLD_URL . ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ?
 			'assets/css/frontend/editor-style.css' :
 			'dist/css/editor-style.min.css' );
+}
+
+/**
+ * Add async/defer attributes to enqueued scripts that have the specified script_execution flag.
+ *
+ * @link https://core.trac.wordpress.org/ticket/12009
+ * @param string $tag    The script tag.
+ * @param string $handle The script handle.
+ * @return string
+ */
+function script_loader_tag( $tag, $handle ) {
+	$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );
+
+	if ( ! $script_execution ) {
+		return $tag;
+	}
+
+	if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
+		return $tag; // _doing_it_wrong()?
+	}
+
+	// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?
+	foreach ( wp_scripts()->registered as $script ) {
+		if ( in_array( $handle, $script->deps, true ) ) {
+			return $tag;
+		}
+	}
+
+	// Add the attribute if it hasn't already been added.
+	if ( ! preg_match( ":\s$script_execution(=|>|\s):", $tag ) ) {
+		$tag = preg_replace( ':(?=></script>):', " $script_execution", $tag, 1 );
+	}
+
+	return $tag;
 }


### PR DESCRIPTION
Fixes #56

This allows a hook to add defer/async to asset loading.

Please see ticket on Theme Scaffold for further context: [Add the ability to use async and defer on wp_enqueue_script #51](https://github.com/10up/theme-scaffold/issues/51)

Also, same PR is open on Theme Scaffold: [Add async/defer tags for enqueueing scripts #77](https://github.com/10up/theme-scaffold/pull/77)

Note: I'm still not sure how to document the ability to leverage this hook, as it is not currently being used by anything in either scaffolds by default and merely just _exists_ in order to hopefully allow somebody to use it. Thanks.