### PR TITLE
Update Node engine to greater than or equal to 8.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "~8.11"
+    "node": ">=8.11"
   },
   "dependencies": {
     "normalize.css": "^8.0.0"


### PR DESCRIPTION
The `~` in the Node engine requires that 8.11 is installed and will cause errors in some processes which check the Node is using the version specified in the engine.

I believe the intention here is to require at least 8.11 and this pull request fixes that issue. If the intention is different, let's discuss!