### PR TITLE
Update WP_Mock and PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5",
-    "10up/wp_mock": "dev-dev",
+    "phpunit/phpunit": "^8.2",
+    "10up/wp_mock": "dev-master",
     "10up/phpcs-composer": "dev-master"
   },
   "scripts": {

--- a/tests/phpunit/test-tools/TestCase.php
+++ b/tests/phpunit/test-tools/TestCase.php
@@ -8,7 +8,7 @@ use WP_Mock;
 use WP_Mock\Tools\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase {
-	public function run( \PHPUnit\Framework\TestResult $result = null ) :TestResult {
+	public function run( TestResult $result = null ) :TestResult {
 		$this->setPreserveGlobalState( false );
 		return parent::run( $result );
 	}

--- a/tests/phpunit/test-tools/TestCase.php
+++ b/tests/phpunit/test-tools/TestCase.php
@@ -2,20 +2,20 @@
 
 namespace TenUpScaffold;
 
-use PHPUnit_Framework_TestResult;
+use PHPUnit\Framework\TestResult;
 use Text_Template;
 use WP_Mock;
 use WP_Mock\Tools\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase {
-	public function run( \PHPUnit\Framework\TestResult $result = null ) {
+	public function run( \PHPUnit\Framework\TestResult $result = null ) :TestResult {
 		$this->setPreserveGlobalState( false );
 		return parent::run( $result );
 	}
 
 	protected $testFiles = array();
 
-	public function setUp() {
+	public function setUp() :void {
 		if ( ! empty( $this->testFiles ) ) {
 			foreach ( $this->testFiles as $file ) {
 				if ( file_exists( PROJECT . $file ) ) {
@@ -31,7 +31,7 @@ class TestCase extends BaseTestCase {
 		$actions_not_added = $expected_actions = 0;
 		try {
 			WP_Mock::assertActionsCalled();
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			$actions_not_added = 1;
 			$expected_actions  = $e->getMessage();
 		}
@@ -66,7 +66,7 @@ class TestCase extends BaseTestCase {
 	 *
 	 * @param \Text_Template $template
 	 */
-	public function prepareTemplate( \Text_Template $template ) {
+	public function prepareTemplate( Text_Template $template ) {
 		$template->setVar( [
 			'globals' => '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = \'' . $GLOBALS['__PHPUNIT_BOOTSTRAP'] . '\';',
 		] );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

The current set of constraints for WP_Mock and PHPUnit can't be installed using composer.

WP_Mock doesn't have a `dev-dev` version anymore. I suggest replacing it with `dev-master` which is currently the same as `^0.4.2`. These are unstable, but so was `dev-dev`.

The newer versions of WP_Mock also require PHP Unit 7+, and PHPUnit is already at version 8.2, with version 7 reaching EOL in February of 2020. I suggest bumping our suite to `^8.2`. The initial set of tests pass with the code changes here.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

Plugin couldn't complete `composer install` or have Unit Tests. Now it can :)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

`composer.json` currently specifies a minimum version of 7.0 for PHP. Neither WP_Mock nor PHPUnit will work with versions below 7.1, but this might not be an issue - we just maybe need a note in documentation?

I would bid to increase the required PHP version to 7.2 but I can see why we may want to keep it at 7.0.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

```
$ vendor/bin/phpunit 
PHPUnit 8.2.3 by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Time: 708 ms, Memory: 12.00 MB

OK (5 tests, 5 assertions)
```


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
