### PR TITLE
Reorganize globals, break variables into partials, add default breakp…

### DIFF
--- a/assets/css/frontend/global/colors.css
+++ b/assets/css/frontend/global/colors.css
@@ -1,0 +1,7 @@
+/*
+ * Colors
+ */
+:root {
+	--c-black: #000;
+	--c-white: #fff;
+}

--- a/assets/css/frontend/global/index.css
+++ b/assets/css/frontend/global/index.css
@@ -1,1 +1,2 @@
-/* Global */
+@import url("colors.css");
+@import url("media-queries.css");

--- a/assets/css/frontend/global/media-queries.css
+++ b/assets/css/frontend/global/media-queries.css
@@ -1,0 +1,16 @@
+/*
+ * Media Queries
+ */
+:root {
+
+	@custom-media --bp-tiny ( min-width: 25em ); /* 400px */
+	@custom-media --bp-small ( min-width: 30em ); /* 480px */
+	@custom-media --bp-medium ( min-width: 48em ); /* 768px */
+	@custom-media --bp-large ( min-width: 64em ); /* 1024px */
+	@custom-media --bp-xlarge ( min-width: 80em ); /* 1280px */
+	@custom-media --bp-xxlarge ( min-width: 90em ); /* 1440px */
+
+	/* WP Core Breakpoints (used for the admin bar for example) */
+	@custom-media --wp-small ( min-width: 600px );
+	@custom-media --wp-medium-max (max-width: 782px);
+}

--- a/assets/css/frontend/style.css
+++ b/assets/css/frontend/style.css
@@ -3,8 +3,7 @@
  */
 
 /* Global - global pieces like media queries, mixins and placholders */
-
-/* @import url("global/index"); */
+@import url("global/index");
 
 /* Base - base styles such as fonts, typography, and wordpress overrides */
 


### PR DESCRIPTION
…oints

Related to https://github.com/10up/theme-scaffold/pull/155

Looks like the preference on recent projects has been to break down the variables into several files, which I think make more sense and keep things tidier.
I've removed the variables.css file and created colors.css and media-queries.css
I've also updated media-queries.css to use breakpoints I've seen more frequently across projects and added WP breakpoints used by the admin bar.

Verified that CSS compiles without errors.