### PR TITLE
Removed :root wrapping around media queries

### DIFF
--- a/assets/css/frontend/global/media-queries.css
+++ b/assets/css/frontend/global/media-queries.css
@@ -1,16 +1,13 @@
 /*
  * Media Queries
  */
-:root {
+@custom-media --bp-tiny ( min-width: 25em ); /* 400px */
+@custom-media --bp-small ( min-width: 30em ); /* 480px */
+@custom-media --bp-medium ( min-width: 48em ); /* 768px */
+@custom-media --bp-large ( min-width: 64em ); /* 1024px */
+@custom-media --bp-xlarge ( min-width: 80em ); /* 1280px */
+@custom-media --bp-xxlarge ( min-width: 90em ); /* 1440px */
 
-	@custom-media --bp-tiny ( min-width: 25em ); /* 400px */
-	@custom-media --bp-small ( min-width: 30em ); /* 480px */
-	@custom-media --bp-medium ( min-width: 48em ); /* 768px */
-	@custom-media --bp-large ( min-width: 64em ); /* 1024px */
-	@custom-media --bp-xlarge ( min-width: 80em ); /* 1280px */
-	@custom-media --bp-xxlarge ( min-width: 90em ); /* 1440px */
-
-	/* WP Core Breakpoints (used for the admin bar for example) */
-	@custom-media --wp-small ( min-width: 600px );
-	@custom-media --wp-medium-max (max-width: 782px);
-}
+/* WP Core Breakpoints (used for the admin bar for example) */
+@custom-media --wp-small ( min-width: 600px );
+@custom-media --wp-medium-max (max-width: 782px);


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes issue described/suggested here - https://github.com/10up/plugin-scaffold/issues/111

### Benefits

Will allow compiling of CSS media queries.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fix to allow media queries to compile.
