### PR TITLE
Set cleanStaleWebpackAssets to false for Clean Webpack Plugin.

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -120,7 +120,9 @@ module.exports = {
 		} ),
 
 		// Clean the `dist` folder on build.
-		new CleanWebpackPlugin(),
+		new CleanWebpackPlugin( {
+			cleanStaleWebpackAssets: false,
+		} ),
 
 		// Extract CSS into individual files.
 		new MiniCssExtractPlugin( {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -71,11 +71,10 @@ module.exports = {
 						loader: 'babel-loader',
 						options: {
 							presets: [
-								[ '@babel/preset-env',
-									{
-										'useBuiltIns': 'usage',
-										'corejs': 3,
-									} ]
+								[ '@babel/preset-env', {
+									'useBuiltIns': 'usage',
+									'corejs': 3,
+								} ]
 							],
 							cacheDirectory: true,
 							sourceMap: ! isProduction,
@@ -120,7 +119,9 @@ module.exports = {
 		} ),
 
 		// Clean the `dist` folder on build.
-		new CleanWebpackPlugin(),
+		new CleanWebpackPlugin( {
+			cleanStaleWebpackAssets: false,
+		} ),
 
 		// Extract CSS into individual files.
 		new MiniCssExtractPlugin( {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -71,10 +71,11 @@ module.exports = {
 						loader: 'babel-loader',
 						options: {
 							presets: [
-								[ '@babel/preset-env', {
-									'useBuiltIns': 'usage',
-									'corejs': 3,
-								} ]
+								[ '@babel/preset-env',
+									{
+										'useBuiltIns': 'usage',
+										'corejs': 3,
+									} ]
 							],
 							cacheDirectory: true,
 							sourceMap: ! isProduction,
@@ -119,9 +120,7 @@ module.exports = {
 		} ),
 
 		// Clean the `dist` folder on build.
-		new CleanWebpackPlugin( {
-			cleanStaleWebpackAssets: false,
-		} ),
+		new CleanWebpackPlugin(),
 
 		// Extract CSS into individual files.
 		new MiniCssExtractPlugin( {


### PR DESCRIPTION
This MR has the same fix made on Theme Scaffold by @samikeijonen on https://github.com/10up/theme-scaffold/issues/165 / https://github.com/10up/theme-scaffold/pull/169.