### PR TITLE
Configure webpack jsonpFunction to be project-specific

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -32,6 +32,13 @@ module.exports = {
 	output: {
 		path: path.resolve(process.cwd(), settings.paths.dist.base),
 		filename: settings.filename.js,
+		/**
+		 * If multiple webpack runtimes (from different compilations) are used on the same webpage,
+		 * there is a risk of conflicts of on-demand chunks in the global namespace.
+		 *
+		 * @see (@link https://webpack.js.org/configuration/output/#outputjsonpfunction)
+		 */
+		jsonpFunction: '__TenUpScaffold_webpackJsonp',
 	},
 
 	// Console stats output.


### PR DESCRIPTION
### Description of the Change

This PR configures the webpack [`output.jsonpFunction`](https://webpack.js.org/configuration/output/#outputjsonpfunction) setting to use a project-specific value.

From the docs:
> Only used when target is set to 'web', which uses JSONP for loading on-demand chunks.
> A JSONP function name used to asynchronously load chunks or join multiple initial chunks (SplitChunksPlugin, AggressiveSplittingPlugin).

The warning about what this PR addresses:

> If multiple webpack runtimes (from different compilations) are used on the same webpage, there is a risk of conflicts of on-demand chunks in the global namespace.

This is because when a bundle is loaded in the browser, it does something like this (where `webpackJsonp` is the default value of this configuration: 

```js
window.webpackJsonp = window.webpackJsonp || []
```

If multiple runtimes use the same array it's possible for one runtime to load a chunk from another due to conflicting internal module IDs, which is not hard since they're simply integers.

For more info on a real-world bug that was fixed by this, see https://github.com/google/site-kit-wp/pull/1690

### Alternate Designs

N/A

### Benefits

Reduced possibility of a very obscure bug

### Possible Drawbacks

None

### Verification Process

See the PR linked above for the bug that this fixed

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

N/A

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
