### PR TITLE
do not remove the viewbox from svgs

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -143,6 +143,13 @@ module.exports = {
 		new ImageminPlugin({
 			disable: !isProduction,
 			test: settings.ImageminPlugin.test,
+			svgo: {
+				plugins: [
+					{
+						removeViewBox: false,
+					},
+				],
+			},
 		}),
 
 		// Lint CSS.


### PR DESCRIPTION
## Description of the Change

Opened an issue here: https://github.com/10up/plugin-scaffold/issues/130

### Benefits

SVGs will display correctly on deployment

### Possible Drawbacks

Perhaps there is a reason viewbox is removed which I am unaware of.

### Verification Process

1. If you site has SVGs, run `npm run build` to see the cropping
2. `npm run watch` does not include the cropping because `ImageminPlugin` is disabled on non-production environments,.

### Checklist:

- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Allowed for the display of SVG `viewbox` attributes when built in a production environment.
