### PR TITLE
Fix incorrect slash in file_exists()

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -33,6 +33,6 @@ register_deactivation_hook( __FILE__, '\TenUpScaffold\Core\deactivate' );
 TenUpScaffold\Core\setup();
 
 // Require Composer autoloader if it exists.
-if ( file_exists( TENUP_SCAFFOLD_PATH . '/vendor/autoload.php' ) ) {
+if ( file_exists( TENUP_SCAFFOLD_PATH . 'vendor/autoload.php' ) ) {
 	require_once TENUP_SCAFFOLD_PATH . 'vendor/autoload.php';
 }


### PR DESCRIPTION
The check if vendor/autoload.php exists contains a superfluous slash:

The call to `file_exists()` looks for:

`TENUP_SCAFFOLD_PATH . '/vendor/autoload.php'`

...where the subsequent include wants to use

`require_once TENUP_SCAFFOLD_PATH . 'vendor/autoload.php'`